### PR TITLE
fix : next.config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,7 @@
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
-  exportPathMap: function () {
+  generateStaticParams: function () {
     return {
       '/': { page: '/' },
       'src/app/(logged)/@modal/(.)member/:id': { page: '/member/:id' }, // correct


### PR DESCRIPTION
- vercel 빌드 중 오류(1)
-  `The "exportPathMap" configuration cannot be used with the "app" directory. Please use generateStaticParams() instead.`